### PR TITLE
Remove test that randomly fail

### DIFF
--- a/test/test_name_ru.rb
+++ b/test/test_name_ru.rb
@@ -18,11 +18,6 @@ class TestFakerNameRu < Test::Unit::TestCase
     assert same_sex?(@words)
   end
 
-  def test_uniqueness
-    unique_names = (1..10000).map { @tester.name }.uniq.size
-    assert unique_names > 9850, "got only #{unique_names} unique names out of 10000"
-  end
-
   def test_last_name
     assert @tester.last_name.match(/[А-Я][а-я]+/)
   end


### PR DESCRIPTION
Hi, I found this test, that fails with very low chance.

```bash
Started
.....................................................................................................................................
..........................................................................................................................F
=====================================================================================================================================
Failure:
  got only 9845 unique names out of 10000.
  <false> is not true.
test_uniqueness(TestFakerNameRu)
/Users/name/Documents/ffaker/test/test_name_ru.rb:23:in `test_uniqueness'
     20:
     21:   def test_uniqueness
     22:     unique_names = (1..10000).map { @tester.name }.uniq.size
  => 23:     assert unique_names > 9850, "got only #{unique_names} unique names out of 10000"
     24:   end
     25:
     26:   def test_last_name
=====================================================================================================================================
.....................................................................................................................................
.........................................................................................

Finished in 0.44753 seconds.
-------------------------------------------------------------------------------------------------------------------------------------
478 tests, 10709 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
99.7908% passed
-------------------------------------------------------------------------------------------------------------------------------------
1068.08 tests/s, 23929.12 assertions/s
rake aborted!
```

Actually, this does not test uniqueness. So I think this test is pointless. 