### PR TITLE
Fix randomly fail tests

### DIFF
--- a/test/test_identification_co.rb
+++ b/test/test_identification_co.rb
@@ -7,32 +7,26 @@ class TestFakerIdentificationESCO < Test::Unit::TestCase
   end
 
   def test_drivers_license
-    # pattern \d{6,14}
-    assert_match /\d{6,14}/, @tester.drivers_license
-    assert @tester.drivers_license.length.between?(6,14)
+    assert_match(/\A\d{6,14}\z/, @tester.drivers_license)
   end
 
   def test_id
-    assert @tester.method_defined? :id
+    assert @tester.method_defined?(:id)
   end
 
   def test_gender
-    assert_match /(Hombre|Mujer)/, @tester.gender
+    assert_match(/\A(Hombre|Mujer)\z/, @tester.gender)
   end
 
   def test_category
-    assert_match /^([a][1-2]|[bc][1-3])$/i, @tester.driver_license_category
+    assert_match(/\A([a][1-2]|[bc][1-3])\z/i, @tester.driver_license_category)
   end
 
   def test_blood_type
-    assert_match /^(a|b|o|ab)[\+|\-]$/i, @tester.blood_type
+    assert_match(/\A(a|b|o|ab)[+-]\z/i, @tester.blood_type)
   end
 
   def test_expedition_date
-    test_today = Date.today
-    # 1 today is bigger than result
-    # 0 today is the same day as result
-    # -1 today is smaller than expected
-    assert_equal(1, test_today <=> @tester.expedition_date)
+    assert(Date.today >= @tester.expedition_date)
   end
 end

--- a/test/test_name_cn.rb
+++ b/test/test_name_cn.rb
@@ -8,6 +8,14 @@ class TestFakerNameCN < Test::Unit::TestCase
   end
 
   def test_name
-    assert Faker::NameCN.name.length > 2
+    assert_match(/\A.{2,}\z/, @tester.name)
+  end
+
+  def test_first_name
+    assert_match(/\A.{1,2}\z/, @tester.first_name)
+  end
+
+  def test_last_name
+    assert_match(/\A.{1,5}\z/, @tester.last_name)
   end
 end

--- a/test/test_ssn_se.rb
+++ b/test/test_ssn_se.rb
@@ -2,7 +2,7 @@
 
 require 'helper'
 
-class TestSSN < Test::Unit::TestCase
+class TestSSNSE < Test::Unit::TestCase
 
   def test_ssn_format
     ssn = Faker::SSNSE.ssn
@@ -14,14 +14,14 @@ class TestSSN < Test::Unit::TestCase
   end
 
   def test_ssn_with_gender
-    ssn_male = Faker::SSNSE.ssn(:gender => :male)
+    ssn_male = Faker::SSNSE.ssn(gender: :male)
     assert is_equal?(ssn_male[10].to_i)
 
-    ssn_female = Faker::SSNSE.ssn(:gender => :female)
+    ssn_female = Faker::SSNSE.ssn(gender: :female)
     assert is_equal?(ssn_female[10].to_i)
 
     assert_raise ArgumentError do
-      Faker::SSNSE.ssn(:gender => :unkown)
+      Faker::SSNSE.ssn(gender: :unkown)
     end
   end
 
@@ -30,14 +30,13 @@ class TestSSN < Test::Unit::TestCase
       from = Time.local(1980, 2, 28)
       to = Time.local(2000, 2, 28)
 
-      ssn = Faker::SSNSE.ssn(:from => from, :to => to)
+      ssn = Faker::SSNSE.ssn(from: from, to: to)
       year = ssn[0..3].to_i
       month = ssn[4..5].to_i
       day = ssn[6..7].to_i
       ssn_birth_date = Time.local(year, month, day)
-
       assert ssn_birth_date < to
-      assert ssn_birth_date > from
+      assert ssn_birth_date >= from
     end
   end
 end


### PR DESCRIPTION
I found another fail test.

```
====================================================================================================================================================================
Failure: <false> is not true.
test_ssn_with_from_to(TestSSNSE)
/Users/user/Documents/ffaker/test/test_ssn_se.rb:41:in `block in test_ssn_with_from_to'
     38:       ssn_birth_date = Time.local(year, month, day)
     39:       p ssn
     40:       assert ssn_birth_date < to
  => 41:       assert ssn_birth_date > from
     42:     end
     43:   end
     44: end
/Users/user/Documents/ffaker/test/test_ssn_se.rb:29:in `times'
/Users/user/Documents/ffaker/test/test_ssn_se.rb:29:in `test_ssn_with_from_to'
====================================================================================================================================================================
.......................................................

Finished in 0.429096 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
480 tests, 10698 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
99.7917% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
1118.63 tests/s, 24931.48 assertions/s
rake aborted!


==================================================================================================================================
Failure: test_expedition_date(TestFakerIdentificationESCO)
/Users/user/Documents/ffaker/test/test_identification_co.rb:36:in `test_expedition_date'
     33:     # 1 today is bigger than result
     34:     # 0 today is the same day as result
     35:     # -1 today is smaller than expected
  => 36:     assert_equal(1, test_today <=> @tester.expedition_date)
     37:   end
     38: end
<1> expected but was
<0>
==================================================================================================================================
..................................................................................................................................
..................................................................................................................................
............................................................................

Finished in 0.451165 seconds.
----------------------------------------------------------------------------------------------------------------------------------
482 tests, 10715 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
99.7925% passed
----------------------------------------------------------------------------------------------------------------------------------
1068.35 tests/s, 23749.63 assertions/s
rake aborted!
```

`random_birth_time_between` can return `from` date.
```ruby
    def random_birth_time_between(from=::Time.local(1940, 1, 1), to=::Time.now)
      ::Time.at(from + rand * (to.to_f - from.to_f))
    end
```

also, `expedition_date` can return today
```ruby
    def expedition_date
      today = Date.today
      today - rand(today.year)
    end
```