### PR TITLE
Never include zeroes within a multi-digit number string.

### DIFF
--- a/lib/ffaker.rb
+++ b/lib/ffaker.rb
@@ -17,7 +17,7 @@ module FFaker
   end
 
   def self.numerify(*masks)
-    masks.flatten.sample.gsub(/#/) { rand(10).to_s }
+    masks.flatten.sample.gsub(/#/) { rand(1..9).to_s }
   end
 
   def self.letterify(*masks)


### PR DESCRIPTION
For example, the string `"0123456789"` exhibits strange behavior when parsing as a phone number. The leading zero often gets thrown out.