### PR TITLE
Support fixed length passwords

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -84,7 +84,7 @@ module FFaker
       while temp.length < min_length
         temp += Lorem.word
       end
-      if max_length > min_length && temp.length > max_length
+      if max_length >= min_length && temp.length > max_length
         temp = temp.slice(0, max_length)
       end
 

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -81,6 +81,10 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.password(1, 3).length < 4
   end
 
+  def test_password_fixed_length
+    assert @tester.password(20, 20).length == 20
+  end
+
   def test_password_strange_argument
     assert @tester.password(10, 2).length > 9
     assert @tester.password(3, 1).length > 2


### PR DESCRIPTION
Adds support for generating fixed length passwords with `FFaker::Internet.password(20, 20)`

Before this patch using the same length for min & max length would result in max length being ignored.